### PR TITLE
docs: add shortTitle support

### DIFF
--- a/additional.d.ts
+++ b/additional.d.ts
@@ -1,4 +1,5 @@
 type FrontMatter = {
   title?: string;
+  shortTitle?: string;
   weight?: number;
 };

--- a/pages/docs/[[...slug]].tsx
+++ b/pages/docs/[[...slug]].tsx
@@ -81,13 +81,13 @@ export const getServerSideProps: GetStaticProps = async (context) => {
         const contents = (await readFile(resolve(dir, dirent.name))).toString();
 
         const {
-          attributes: { title, weight },
+          attributes: { shortTitle, title, weight },
         } = fm<FrontMatter>(contents);
         node.addChild(
           new TreeItemConstructor(
             removeExt(dirent.name),
             current,
-            title ? title : null,
+            title ? shortTitle || title : null,
             weight ? weight : 0
           )
         );


### PR DESCRIPTION
so yeah, the nvidia wayland guide needs a shortTitle because the title will overflow the tree thing
![image](https://user-images.githubusercontent.com/80879058/190883320-c1dc3605-945c-41c7-b543-6ddfc1b98eee.png)

this will be implemented in the mdx file and you don't need it in the file as it will fallback to the title property.

something like this

```yaml
shortTitle: hi
title: hello this is a longer title
```